### PR TITLE
fixed loadTestsFromModule

### DIFF
--- a/src/stepic_utils/quiz.py
+++ b/src/stepic_utils/quiz.py
@@ -321,7 +321,7 @@ class QuizTestLoader(unittest.TestLoader):
         super().__init__()
 
     def loadTestsFromModule(self, module, use_load_tests=True):
-        suite = super().loadTestsFromModule(module, use_load_tests)
+        suite = super().loadTestsFromModule(module)
         suite.addTest(self.quiz_cls.load_tests(module))
         return suite
 


### PR DESCRIPTION
In Python 3.12, the unittest.TestLoader.loadTestsFromModule method has changed its signature and no longer accepts a use_load_tests argument. This throws an error because our QuizTestLoader subclass is still trying to pass use_load_tests to the parent method.